### PR TITLE
Update remaining references to WHATWG and Web of Sensors CG

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 For significant contributions (i.e., non-editorial changes to the API), 
 we require you to become a member of the 
-[Web of Sensors CG](http://www.w3.org/community/sensorweb/). This helps 
+[Web Platform Incubator CG](http://www.w3.org/community/wicg/). This helps 
 keep the spec royalty free and gives us some patent protection! 
 
 This spec is written using [ReSpec](http://w3.org/respec/). For

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 ### Code of conduct
 
-We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [WHATWG Code of Conduct](https://whatwg.org/code-of-conduct).
+We are committed to providing a friendly, safe and welcoming environment for all. Please read and respect the [W3C Code of Ethics and Professional Conduct](https://www.w3.org/Consortium/cepc/).

--- a/respecConfig.js
+++ b/respecConfig.js
@@ -36,18 +36,18 @@ var respecConfig = {
   editors: [
     {
       name: "See contributors on GH",
-      url: "https://github.com/whatwg/serial/graphs/contributors"
-              },
-          ],
+      url: "https://github.com/wicg/serial/graphs/contributors"
+    },
+  ],
 
   // name of the WG
-  wg: "A Web of Sensors Community Group / WHATWG Joint",
+  wg: "Web Platform Incubator Community Group",
 
   // URI of the public WG page
-  wgURI: "http://www.w3.org/community/sensorweb/",
+  wgURI: "http://www.w3.org/community/wicg/",
 
   // name (without the @w3c.org) of the public mailing to which comments are due
-  wgPublicList: "public-sensorweb",
+  wgPublicList: "public-wicg",
 
   // URI of the patent status for this WG, for Rec-track documents
   // !!!! IMPORTANT !!!!
@@ -60,15 +60,15 @@ var respecConfig = {
     key: "Repository",
     data: [
       {
-        href: "https://github.com/whatwg/serial"
+        href: "https://github.com/wicg/serial"
       },
       {
         value: "issues",
-        href: "https://github.com/whatwg/serial/issues"
+        href: "https://github.com/wicg/serial/issues"
       },
       {
         value: "Commit History.",
-        href: "https://github.com/whatwg/serial/commits/gh-pages"
+        href: "https://github.com/wicg/serial/commits/gh-pages"
       }]
   }],
   localBiblio: {


### PR DESCRIPTION
These references have been updated to point at the Web Platform Incubator CG instead.