### PR TITLE
remove duplicated productId prop from metadata table

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,11 +169,6 @@ user agents SHOULD use the values provided in they "Key" column of the
     <th>Description</th>
   </tr>
   <tr>
-    <td>Product ID</td>
-    <td>`productId`</td>
-    <td></td>
-  </tr>
-  <tr>
     <td>Serial Number</td>
     <td>`serialNumber`</td>
     <td></td>


### PR DESCRIPTION
:wave: Hello,

Not sure if this was intentional or not, but `productId` is listed twice in the port metadata table. This is a tiny PR to remove one of the instances of it.

Thanks 🙇 