### PR TITLE
Make ParityType enum description render properly

### DIFF
--- a/index.html
+++ b/index.html
@@ -283,16 +283,12 @@ for use.
   <dl>
     <dt><dfn>none</dfn></dt>
     <dd>No parity bit is sent for each data word.</dd>
-
     <dt><dfn>even</dfn></dt>
     <dd>Data word plus parity bit has even parity.</dd>
-
     <dt><dfn>odd</dfn></dt>
     <dd>Data word plus parity bit has odd parity.</dd>
-
     <dt><dfn>mark</dfn></dt>
     <dd>Parity bit has a mark symbol (logical one).</dd>
-
     <dt><dfn>space</dfn></dt>
     <dd>Parity bit has a space symbol (logical zero).</dd>
   </dl>


### PR DESCRIPTION
Probably respec issue, but removing the new lines fixes it