### PR TITLE
Fix copy-paste error in getSignals() algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,11 +1113,11 @@ document.
             "clear to send" or "CTS" signal has been asserted by the device, and
             `false` otherwise.
           <li>
-            Set |signals|["{{SerialInputSignals/dataCarrierDetect}}"] to `true`
+            Set |signals|["{{SerialInputSignals/ringIndicator}}"] to `true`
             if the "ring indicator" or "RI" signal has been asserted by the
             device, and `false` otherwise.
           <li>
-            Set |signals|["{{SerialInputSignals/dataCarrierDetect}}"] to `true`
+            Set |signals|["{{SerialInputSignals/dataSetReady}}"] to `true`
             if the "data set ready" or "DSR" signal has been asserted by the
             device, and `false` otherwise.
           <li>


### PR DESCRIPTION
Rather than setting "ringIndicator" and "dataSetReady" the steps reset "dataCarrierDetect" two more times.

Fixes #118.