### PR TITLE
requestPort() throws a NotFoundError

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ document.
           <li>
             If the user does not choose a port, [=queue a global task=] on the
             [=relevant global object=] of [=this=] using the [=serial port task
-            source=] to [=reject=] |promise| with an {{"AbortError"}}
+            source=] to [=reject=] |promise| with an {{"NotFoundError"}}
             {{DOMException}} and abort these steps.
           <li>
             Let |port:SerialPort| be a {{SerialPort}} representing the port

--- a/index.html
+++ b/index.html
@@ -159,7 +159,7 @@ document.
           <li>
             If the user does not choose a port, [=queue a global task=] on the
             [=relevant global object=] of [=this=] using the [=serial port task
-            source=] to [=reject=] |promise| with an {{"NotFoundError"}}
+            source=] to [=reject=] |promise| with a {{"NotFoundError"}}
             {{DOMException}} and abort these steps.
           <li>
             Let |port:SerialPort| be a {{SerialPort}} representing the port


### PR DESCRIPTION
When the user does not select a port Chromium throws a `NotFoundError`, not an `AbortError`.