### PR TITLE
Editorial: associate slots with interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -341,7 +341,7 @@ document.
   Instances of {{SerialPort}} are created with the internal slots described in
   the following table:
 
-  <table class="simple">
+  <table class="simple" data-dfn-for="SerialPort">
     <tr>
       <th>Internal slot
       <th>Initial value


### PR DESCRIPTION
Fixes ReSpec errors. Recent change to ReSpec mandates that internal slots must be "for" something explicitly. 