### PR TITLE
Add SerialPort.forget() method

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,7 @@ document.
       Promise&lt;undefined> setSignals(optional SerialOutputSignals signals = {});
       Promise&lt;SerialInputSignals> getSignals();
       Promise&lt;undefined> close();
+      Promise&lt;undefined> forget();
     };
   </pre>
 
@@ -1316,6 +1317,32 @@ document.
                 |promise| with |r|.
             </ol>
         </ul>
+      <li>Return |promise|.
+    </ol>
+  </section>
+  <section>
+    <h3><dfn>forget()</dfn> method</h3>
+
+    <aside class="example">
+      It is posssible to voluntarily revoke a permission to a serial port that was granted by a user.
+
+      <pre class="js">
+        // Request a serial port.
+        const port = await navigator.serial.requestPort();
+
+        // Then later... revoke permission to the serial port.
+        await port.forget();
+      </pre>
+    </aside>
+
+    The {{SerialPort/forget()}} method steps are:
+
+    <ol>
+      <li>Let |promise| be [=a new promise=].
+      <li>
+        Remove |this| from the sequence of available serial ports on
+        the system which the user has allowed the site to access as the
+        result of a previous call to {{Serial/requestPort()}}.
       <li>Return |promise|.
     </ol>
   </section>

--- a/index.html
+++ b/index.html
@@ -1267,6 +1267,9 @@ document.
     <ol>
       <li>Let |promise| be [=a new promise=].
       <li>
+        If [=this=].{{SerialPort/[[state]]}} is not `"opened"`, reject |promise| with an
+        "{{InvalidStateError}}" {{DOMException}} and return |promise|.
+      <li>
         Let |cancelPromise:Promise| be the result of invoking
         [=ReadableStream/cancel=] on [=this=].{{SerialPort/[[readable]]}} or [=a promise
         resolved with=] `undefined` if [=this=].{{SerialPort/[[readable]]}} is `null`.
@@ -1339,10 +1342,18 @@ document.
 
     <ol>
       <li>Let |promise| be [=a new promise=].
+      <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgetting"`.
       <li>
-        Remove |this| from the sequence of available serial ports on
+        If [=this=].{{SerialPort/[[readable]]}} is not `null`, invoke
+        [=ReadableStream/cancel=] on [=this=].{{SerialPort/[[readable]]}}.
+      <li>
+        If [=this=].{{SerialPort/[[writable]]}} is not `null`, invoke
+        [=WritableStream/abort=] on [=this=].{{SerialPort/[[writable]]}}.
+      <li>
+        Remove [=this=] from the sequence of available serial ports on
         the system which the user has allowed the site to access as the
         result of a previous call to {{Serial/requestPort()}}.
+      <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgotten"`.
       <li>Return |promise|.
     </ol>
   </section>

--- a/index.html
+++ b/index.html
@@ -748,6 +748,11 @@ document.
                     an "{{UnknownError}}" {{DOMException}} and invoke the steps
                     to [=handle closing the readable stream=].
                   <li>
+                    If [=this=].{{SerialPort/[[state]]}} becomes `"forgotten"`, invoke
+                    [=ReadableStream/error=] on [=this=].{{SerialPort/[[readable]]}} with
+                    an "{{NetworkError}}" {{DOMException}} and invoke the steps
+                    to [=handle closing the readable stream=].
+                  <li>
                     If the port was disconnected, run the following steps:
                     <ol>
                       <li>Set [=this=].{{SerialPort/[[readFatal]]}} to `true`,
@@ -902,6 +907,17 @@ document.
                   <li>
                     If an operating system error was encountered, [=reject=]
                     |promise| with an "{{UnknownError}}" {{DOMException}}.
+                  <li>
+                    If [=this=].{{SerialPort/[[state]]}} becomes `"forgotten"`,
+                    run the following steps:
+                    <ol>
+                      <li>
+                        [=Reject=] |promise| with a "{{NetworkError}}"
+                        {{DOMException}}.
+                      <li>
+                        Invoke the steps to [=handle closing the writable
+                        stream=].
+                    </ol>
                   <li>
                     If the port was disconnected, run the following steps:
                     <ol>
@@ -1342,6 +1358,10 @@ document.
 
     <ol>
       <li>Let |promise| be [=a new promise=].
+      <li>
+        If the user agent can't perform this action (e.g. permission was granted
+        by administrator policy), reject |promise| with a "{{NotAllowedError}}"
+        {{DOMException}} and return |promise|.
       <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgetting"`.
       <li>
         If [=this=].{{SerialPort/[[readable]]}} is not `null`, invoke

--- a/index.html
+++ b/index.html
@@ -1358,12 +1358,6 @@ document.
         <ol>
           <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgetting"`.
           <li>
-            If [=this=].{{SerialPort/[[readable]]}} is not `null`, invoke
-            [=ReadableStream/cancel=] on [=this=].{{SerialPort/[[readable]]}}.
-          <li>
-            If [=this=].{{SerialPort/[[writable]]}} is not `null`, invoke
-            [=WritableStream/abort=] on [=this=].{{SerialPort/[[writable]]}}.
-          <li>
             Remove [=this=] from the sequence of available serial ports on
             the system which the user has allowed the site to access as the
             result of a previous call to {{Serial/requestPort()}}.

--- a/index.html
+++ b/index.html
@@ -705,6 +705,11 @@ document.
                 Invoke the operating system to read up to |desiredSize| bytes
                 from the port, putting the result in the [=byte sequence=]
                 |bytes|.
+
+                <div class="note">
+                  [=this=].{{SerialPort/[[state]]}} becoming `"forgotten"`
+                  must be treated as if |the port was disconnected|.
+                </div>
               <li>
                 [=Queue a global task=] on the [=relevant global object=] of
                 [=this=] using the [=serial port task source=] to run the
@@ -748,12 +753,7 @@ document.
                     an "{{UnknownError}}" {{DOMException}} and invoke the steps
                     to [=handle closing the readable stream=].
                   <li>
-                    If [=this=].{{SerialPort/[[state]]}} becomes `"forgotten"`, invoke
-                    [=ReadableStream/error=] on [=this=].{{SerialPort/[[readable]]}} with
-                    an "{{NetworkError}}" {{DOMException}} and invoke the steps
-                    to [=handle closing the readable stream=].
-                  <li>
-                    If the port was disconnected, run the following steps:
+                    If |the port was disconnected|, run the following steps:
                     <ol>
                       <li>Set [=this=].{{SerialPort/[[readFatal]]}} to `true`,
                       <li>
@@ -886,6 +886,11 @@ document.
                   |bytes| has been queued for transmission rather than after it
                   has been transmitted.
                 </div>
+
+                <div class="note">
+                  [=this=].{{SerialPort/[[state]]}} becoming `"forgotten"`
+                  must be treated as if |the port was disconnected|.
+                </div>
               <li>
                 [=Queue a global task=] on the [=relevant global object=] of
                 [=this=] using the [=serial port task source=] to run the
@@ -908,18 +913,7 @@ document.
                     If an operating system error was encountered, [=reject=]
                     |promise| with an "{{UnknownError}}" {{DOMException}}.
                   <li>
-                    If [=this=].{{SerialPort/[[state]]}} becomes `"forgotten"`,
-                    run the following steps:
-                    <ol>
-                      <li>
-                        [=Reject=] |promise| with a "{{NetworkError}}"
-                        {{DOMException}}.
-                      <li>
-                        Invoke the steps to [=handle closing the writable
-                        stream=].
-                    </ol>
-                  <li>
-                    If the port was disconnected, run the following steps:
+                    If |the port was disconnected|, run the following steps:
                     <ol>
                       <li>Set [=this=].{{SerialPort/[[writeFatal]]}} to `true`.
                       <li>
@@ -1357,24 +1351,29 @@ document.
     The {{SerialPort/forget()}} method steps are:
 
     <ol>
-      <li>Let |promise| be [=a new promise=].
       <li>
         If the user agent can't perform this action (e.g. permission was granted
-        by administrator policy), reject |promise| with a "{{NotAllowedError}}"
-        {{DOMException}} and return |promise|.
-      <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgetting"`.
-      <li>
-        If [=this=].{{SerialPort/[[readable]]}} is not `null`, invoke
-        [=ReadableStream/cancel=] on [=this=].{{SerialPort/[[readable]]}}.
-      <li>
-        If [=this=].{{SerialPort/[[writable]]}} is not `null`, invoke
-        [=WritableStream/abort=] on [=this=].{{SerialPort/[[writable]]}}.
-      <li>
-        Remove [=this=] from the sequence of available serial ports on
-        the system which the user has allowed the site to access as the
-        result of a previous call to {{Serial/requestPort()}}.
-      <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgotten"`.
-      <li>Return |promise|.
+        by administrator policy), return [=a promise resolved with=] `undefined`.
+      <li>Run the following steps [=in parallel=]:
+        <ol>
+          <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgetting"`.
+          <li>
+            If [=this=].{{SerialPort/[[readable]]}} is not `null`, invoke
+            [=ReadableStream/cancel=] on [=this=].{{SerialPort/[[readable]]}}.
+          <li>
+            If [=this=].{{SerialPort/[[writable]]}} is not `null`, invoke
+            [=WritableStream/abort=] on [=this=].{{SerialPort/[[writable]]}}.
+          <li>
+            Remove [=this=] from the sequence of available serial ports on
+            the system which the user has allowed the site to access as the
+            result of a previous call to {{Serial/requestPort()}}.
+          <li>Set [=this=].{{SerialPort/[[state]]}} to `"forgotten"`.
+          <li>
+            [=Queue a global task=] on the [=relevant global object=] of
+            [=this=] using the [=serial port task source=] to [=resolve=]
+            |promise| with `undefined`.
+      </ol>
+    <li>Return |promise|.
     </ol>
   </section>
 </section>


### PR DESCRIPTION
Following https://github.com/WICG/webhid/pull/84 and https://github.com/WICG/webusb/pull/214, this PR is an attempt to provide a way for web developers to revoke permission access to a paired SerialPort.

```js
// Request a serial port.
const port = await navigator.serial.requestPort();

// Then later... revoke permission to the serial port.
await port.forget();
```

@reillyeon Please have a look

FIX: #132