### PR TITLE
Fail if filter contains both bluetooth and usb members

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,6 +144,19 @@
           |options|["{{SerialPortRequestOptions/filters}}"] run the following
           steps:
             <ol>
+              <li>If |filter|["{{SerialPortFilter/bluetoothServiceClassId}}"] is
+              present:
+                <ol>
+                  <li>
+                    If |filter|["{{SerialPortFilter/usbVendorId}}"] is present,
+                    [=reject=] |promise| with a {{TypeError}} and return |promise|.
+                  </li>
+                  <li>
+                    If |filter|["{{SerialPortFilter/usbProductId}}"] is present,
+                    [=reject=] |promise| with a {{TypeError}} and return |promise|.
+                  </li>
+                </ol>
+              </li>
               <li>If |filter|["{{SerialPortFilter/usbVendorId}}"] is not
               present, [=reject=] |promise| with a {{TypeError}} and return
               |promise|.


### PR DESCRIPTION
This PR makes sure `requestPort()` fails if filter contains both bluetooth and usb members. This matches [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/serial/serial.cc;l=164;drc=9ed4a90ee6aeaa3c1911d229dec6317d8fe8260d).

```cpp
  if (filter->hasBluetoothServiceClassId()) {
    if (filter->hasUsbVendorId() || filter->hasUsbProductId()) {
      exception_state.ThrowTypeError(
          "A filter cannot specify both bluetoothServiceClassId and "
          "usbVendorId or usbProductId.");
      return nullptr;
    }
```

@nondebug @reillyeon Please review.