### PR TITLE
An example of using SerialPort.connected

### DIFF
--- a/EXPLAINER_BLUETOOTH.md
+++ b/EXPLAINER_BLUETOOTH.md
@@ -220,6 +220,25 @@ applications identify whether a connection attempt is likely to succeed, a
 `SerialPort.connected` attribute will be added to indicate whether the port is
 logically connected.
 
+The below examples shows how `SerialPort.connected` attribute can be used to
+inform user right actions if the Bluetooth device is not powered on or not in
+the proximity of the system.
+
+```javascript
+// Assuming we have `port`, which is a wireless serial port.
+try {
+   await port.open({baudRate: 115200});
+} catch(e) {
+   if (!port.connected) {
+      // Inform the user that the Bluetooth device might be out of range
+      // or powered off, as it's currently not connectable.
+      return;
+   }
+   // Other types of error handling.
+}
+```
+
+
 ## Security Considerations
 
 This API change poses security risks that are a superset of those of the Web

--- a/EXPLAINER_BLUETOOTH.md
+++ b/EXPLAINER_BLUETOOTH.md
@@ -225,16 +225,15 @@ inform user right actions if the Bluetooth device is not powered on or not in
 the proximity of the system.
 
 ```javascript
-// Assuming we have `port`, which is a wireless serial port.
-try {
-   await port.open({baudRate: 115200});
-} catch(e) {
-   if (!port.connected) {
-      // Inform the user that the Bluetooth device might be out of range
-      // or powered off, as it's currently not connectable.
-      return;
-   }
-   // Other types of error handling.
+let ports = await navigator.serial.getPorts();
+for (let port of ports) {
+  if (port.connected) {
+    await port.open({baudRate: 115200});
+  } else {
+    // Prompt the user to make sure the Bluetooth device is connectable to the system.
+    // Once the user thinks the device is ready to connect, the user can press a
+    // a button which runs `port.open` to trigger a connection attempt.
+  }
 }
 ```
 


### PR DESCRIPTION
Add an example for using `SerialPort.connected` per request from https://groups.google.com/a/chromium.org/g/blink-dev/c/KPN62vo5Pp4/m/Kc8tkB1eAAAJ.