### PR TITLE
Add id member in SerialPortInfo

### DIFF
--- a/index.html
+++ b/index.html
@@ -635,9 +635,21 @@
               </li>
             </ol>
           </li>
+          <li>If the port is [=identifiable=], perform the following steps:
+              <ol>
+                <li>Set |info|["{{SerialPortInfo/id}}"] to the [=identifier=]
+                  of the port.
+                </li>
+              </ol>
+            </li>
           <li>Return |info|.
           </li>
         </ol>
+        <p>
+          A serial port is <dfn>identifiable</dfn> if the port can be uniquely
+          identified through an <dfn>identifier</dfn> across the user agent
+          restarts while it remains [=logically connected=].
+        </p>
         <section data-dfn-for="SerialPortInfo">
           <h4>
             <dfn>SerialPortInfo</dfn> dictionary
@@ -647,6 +659,7 @@
         unsigned short usbVendorId;
         unsigned short usbProductId;
         BluetoothServiceUUID bluetoothServiceClassId;
+        DOMString id;
       };
           </pre>
           <dl>
@@ -673,6 +686,14 @@
               If the port is a service on a Bluetooth device this member will
               be a {{BluetoothServiceUUID}} containing the service class UUID.
               Otherwise it will be `undefined`.
+            </dd>
+            <dt>
+              <dfn>id</dfn> member
+            </dt>
+            <dd>
+              If the port is [=identifiable=], this member will be a
+              {{DOMString}} representing the [=identifier=] of the port. Otherwise
+              it will be `undefined`.
             </dd>
           </dl>
         </section>


### PR DESCRIPTION
This PR proposed an `id` attribute in `SerialPortInfo` hoping to address https://github.com/WICG/serial/issues/128.

This `id` attribute will only present if there is such an identifier exposed by the system (e.g. combination of pid, vid and serial number, or system identity like [device instance id](https://learn.microsoft.com/en-us/windows-hardware/drivers/install/device-instance-ids) on Windows).