### PR TITLE
Make readable and writable attributes nullable

### DIFF
--- a/index.html
+++ b/index.html
@@ -436,8 +436,8 @@
       attribute EventHandler onconnect;
       attribute EventHandler ondisconnect;
       readonly attribute boolean connected;
-      readonly attribute ReadableStream readable;
-      readonly attribute WritableStream writable;
+      readonly attribute ReadableStream? readable;
+      readonly attribute WritableStream? writable;
 
       SerialPortInfo getInfo();
 


### PR DESCRIPTION
The stream attributes are nullable as they are initially null before the port is opened and become null after it is closed or a fatal error occurs.

Fixed #219.