### PR TITLE
Reject if baudRate is zero

### DIFF
--- a/index.html
+++ b/index.html
@@ -708,14 +708,16 @@
           |promise| with an "{{InvalidStateError}}" {{DOMException}} and return
           |promise|.
           </li>
+          <li>If |options|["{{SerialOptions/baudRate}}"] is 0, reject |promise|
+          with a {{TypeError}} and return |promise|.
           <li>If |options|["{{SerialOptions/dataBits}}"] is not 7 or 8, reject
-          |promise| with {{TypeError}} and return |promise|.
+          |promise| with a {{TypeError}} and return |promise|.
           </li>
           <li>If |options|["{{SerialOptions/stopBits}}"] is not 1 or 2, reject
-          |promise| with {{TypeError}} and return |promise|.
+          |promise| with a {{TypeError}} and return |promise|.
           </li>
           <li>If |options|["{{SerialOptions/bufferSize}}"] is 0, reject
-          |promise| with {{TypeError}} and return |promise|.
+          |promise| with a {{TypeError}} and return |promise|.
           </li>
           <li>Optionally, if |options|["{{SerialOptions/bufferSize}}"] is
           larger than the implementation is able to support, reject |promise|
@@ -1416,7 +1418,7 @@
           |promise|.
           </li>
           <li>If all of the specified members of |signals| are not present
-          reject |promise| with {{TypeError}} and return |promise|.
+          reject |promise| with a {{TypeError}} and return |promise|.
           </li>
           <li>Perform the following steps [=in parallel=]:
             <div class="note">


### PR DESCRIPTION
The documentation of the baudRate member of SerialOptions says that it must be a non-zero value but this was not checked by the method steps for open().

Fixed #224.